### PR TITLE
Remove duplicate columns related to customer aggregates

### DIFF
--- a/models/intermediate/shopify__customers__order_aggregates.sql
+++ b/models/intermediate/shopify__customers__order_aggregates.sql
@@ -9,8 +9,6 @@ with orders as (
         customer_id,
         min(created_timestamp) as first_order_timestamp,
         max(created_timestamp) as most_recent_order_timestamp,
-        count(*) as number_of_orders,
-        sum(total_price) as lifetime_total_price,
         avg(total_price)  as average_order_value
     from orders
     group by 1

--- a/models/shopify.yml
+++ b/models/shopify.yml
@@ -219,10 +219,6 @@ models:
         description: The timestamp the customer completed their most recent order.
       - name: average_order_value
         description: The average order value for the customer.
-      - name: number_of_orders
-        description: The total number of orders for the customer.
-      - name: lifetime_total_price
-        description: The total amount (in currency) purchased by the customer.
 
   - name: shopify__products
     description: Each record represents a product in Shopify.

--- a/models/shopify__customers.sql
+++ b/models/shopify__customers.sql
@@ -14,9 +14,7 @@ with customers as (
         customers.*,
         orders.first_order_timestamp,
         orders.most_recent_order_timestamp,
-        orders.average_order_value,
-        coalesce(orders.number_of_orders, 0) as number_of_orders,
-        coalesce(orders.lifetime_total_price, 0) as lifetime_total_price
+        orders.average_order_value
     from customers
     left join orders
         using (customer_id)


### PR DESCRIPTION
This PR fixes issue #8.

This is a breaking change; anyone using this package and using the number_of_orders or lifetime_total_price columns will need to update their models to use the ones provided by the source (total_spent and orders_count).