### PR TITLE
Filter out orders without a customer_id in order aggregates by customer

### DIFF
--- a/models/intermediate/shopify__customers__order_aggregates.sql
+++ b/models/intermediate/shopify__customers__order_aggregates.sql
@@ -13,6 +13,7 @@ with orders as (
         sum(total_price) as lifetime_total_price,
         avg(total_price)  as average_order_value
     from orders
+    where customer_id is not null
     group by 1
 
 )


### PR DESCRIPTION
It's possible in Shopify to have orders that are not associated with a customer, depending on the shop configuration or the way the order has been entered in the system (such as using drafts or other channels).

I have occurrences of this in the project I'm working on right now. The `shopify__customers__order_aggregates` model currently assumes that all orders have a customer_id, and tests for not_null on that field, and therefore fails on my project.

Since this model is aggregating by customer, I've modified it to add a where clause, filtering out orders that are not associated to a customer.