### PR TITLE
Added refunds to orders & order_lines models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,7 +5,7 @@ config-version: 2
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 
-models: 
+models:
   shopify:
     materialized: table
     intermediate:
@@ -18,4 +18,4 @@ vars:
     shopify_order_line: "{{ ref('stg_shopify__order_line') }}"
     shopify_order_line_refund: "{{ ref('stg_shopify__order_line_refund') }}"
     shopify_product: "{{ ref('stg_shopify__product') }}"
-
+    shopify_transaction: "{{ ref('stg_shopify__transaction') }}"

--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -13,3 +13,15 @@ models:
         tests:
           - unique
           - not_null
+  - name: shopify__transaction__refund_aggregates
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+  - name: shopify__transaction__refund_line_aggregates
+    columns:
+      - name: refund_id
+        tests:
+          - unique
+          - not_null

--- a/models/intermediate/shopify__transaction__refund_aggregates.sql
+++ b/models/intermediate/shopify__transaction__refund_aggregates.sql
@@ -1,0 +1,18 @@
+with transaction as (
+
+    select *
+    from {{ ref('stg_shopify__transaction') }}
+
+), aggregated as (
+
+    select
+        order_id,
+        sum(amount) AS refunded_amount
+    from transaction
+    WHERE kind = 'refund' AND status = 'success'
+    group by 1
+
+)
+
+select *
+from aggregated

--- a/models/intermediate/shopify__transaction__refund_line_aggregates.sql
+++ b/models/intermediate/shopify__transaction__refund_line_aggregates.sql
@@ -1,0 +1,18 @@
+with transaction as (
+
+    select *
+    from {{ ref('stg_shopify__transaction') }}
+
+), aggregated as (
+
+    select
+        refund_id,
+        sum(amount) AS refund_amount
+    from transaction
+    WHERE kind = 'refund' AND status = 'success'
+    group by 1
+
+)
+
+select *
+from aggregated

--- a/models/shopify.yml
+++ b/models/shopify.yml
@@ -176,7 +176,9 @@ models:
         description: The sequential number of the order as it relates to the customer
       - name: new_vs_repeat
         description: Whether the order was a new or repeat order for the customer.
-  
+      - name: refunded_amount
+        description: The total amount refunded within an order.
+
   - name: shopify__customers
     description: Each record represents a customer in Shopify.
     columns:
@@ -187,7 +189,7 @@ models:
       - name: created_timestamp
         description: The date and time when the customer was created.
       - name: default_address_id
-        description: The default address for the customer. 
+        description: The default address for the customer.
       - name: email
         description: The unique email address of the customer. Attempting to assign the same email address to multiple customers returns an error.
       - name: first_name
@@ -303,9 +305,13 @@ models:
         description: The total amount of the discount allocated to the line item in the shop currency.
       - name: variant_id
         description: The ID of the product variant.
+      - name: refund_id
+        description: The ID associated with a refund.
       - name: vendor
         description: The name of the item's supplier.
       - name: refunded_quantity
         description: Quantity of the item that has been refunded.
       - name: quantity_net_refunds
         description: Quantity ordered, excluding refunds.
+      - name: refunded_amount
+        description: The total amount refunded per line item.

--- a/models/shopify__order_lines.sql
+++ b/models/shopify__order_lines.sql
@@ -1,26 +1,37 @@
 with order_lines as (
 
     select *
-    from {{ var('shopify_order_line') }}
+    from {{ ref('stg_shopify__order_line') }}
 
 ), order_line_refunds as (
 
     select *
-    from {{ var('shopify_order_line_refund') }}
+    from {{ ref('stg_shopify__order_line_refund') }}
+
+), order_line_refund_amounts as (
+
+    select *
+    FROM {{ ref('shopify__transaction__refund_line_aggregates') }}
 
 ), refunds_aggregated as (
 
     select
         order_line_id,
-        sum(quantity) as refunded_quantity
+        refund_id,
+        sum(quantity) as refunded_quantity,
+        sum(refund_amount) AS refunded_amount
     from order_line_refunds
-    group by 1
+    left join order_line_refund_amounts
+        using (refund_id)
+    group by 1,2
 
 ), joined as (
 
     select
         order_lines.*,
+        refunds_aggregated.refund_id,
         coalesce(refunds_aggregated.refunded_quantity,0) as refunded_quantity,
+        coalesce(refunds_aggregated.refunded_amount, 0) AS refunded_amount,
         order_lines.quantity - coalesce(refunds_aggregated.refunded_quantity,0) as quantity_net_refunds
     from order_lines
     left join refunds_aggregated
@@ -28,5 +39,4 @@ with order_lines as (
 
 )
 
-select *
-from joined
+select * from joined

--- a/models/shopify__orders.sql
+++ b/models/shopify__orders.sql
@@ -1,34 +1,44 @@
 with orders as (
 
     select *
-    from {{ var('shopify_order') }}
+    from {{ ref('stg_shopify__order') }}
 
 ), order_lines as (
 
     select *
     from {{ ref('shopify__orders__order_line_aggregates') }}
 
+), refunds AS (
+
+    select
+        *
+    from {{ ref('shopify__transaction__refund_aggregates') }}
+
+
 ), joined as (
 
     select
         orders.*,
+        refunds.refunded_amount,
         order_lines.line_item_count
     from orders
     left join order_lines
         using (order_id)
+    left join refunds
+        using (order_id)
 
 ), windows as (
 
-    select 
+    select
         *,
         row_number() over (partition by customer_id order by created_timestamp) as customer_order_seq_number
     from joined
 
 ), new_vs_repeat as (
 
-    select 
+    select
         *,
-        case 
+        case
             when customer_order_seq_number = 1 then 'new'
             else 'repeat'
         end as new_vs_repeat
@@ -36,5 +46,4 @@ with orders as (
 
 )
 
-select *
-from new_vs_repeat
+select * from new_vs_repeat


### PR DESCRIPTION
Extended functionality of the existing **orders** and **order_lines** models to include refunded amounts. This is based on data from the transaction table.