### PR TITLE
Update metafield dedup key to composite (id, owner_id, owner_resource)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # dbt_shopify v1.10.0
 
+[PR #167](https://github.com/fivetran/dbt_shopify/pull/167) includes the following update:
+
+## Schema/Data Changes
+**1 total change • 0 possible breaking changes**
+
+| Data Model(s) | Change type | Old | New | Notes |
+| ------------- | ----------- | --- | --- | ----- |
+| [`stg_shopify_gql__metafield`](https://fivetran.github.io/dbt_shopify/#!/model/model.shopify.stg_shopify_gql__metafield) | Deduplication logic and `unique_key` value | Deduplicated on `id` only; `unique_key` hashed on `metafield_id` and `source_relation` | Deduplicated on `id`, `owner_id`, and `owner_resource`; `unique_key` hashed on `metafield_id`, `owner_resource_id`, `owner_resource`, and `source_relation` | Shopify changed the underlying `METAFIELD` table's primary key to a composite of `owner_id` and `owner_resource` to fix cross-entity ID collisions. This change does not affect any downstream `shopify_gql__*_metafields` models, since `unique_key` is never selected from `stg_shopify_gql__metafield` into those outputs. |
+
 # dbt_shopify v1.9.2
 
 [PR #164](https://github.com/fivetran/dbt_shopify/pull/164) includes the following updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # dbt_shopify v1.10.0
 
-[PR #167](https://github.com/fivetran/dbt_shopify/pull/167) includes the following update:
-
-## Schema/Data Changes
-**1 total change • 0 possible breaking changes**
-
-| Data Model(s) | Change type | Old | New | Notes |
-| ------------- | ----------- | --- | --- | ----- |
-| [`stg_shopify_gql__metafield`](https://fivetran.github.io/dbt_shopify/#!/model/model.shopify.stg_shopify_gql__metafield) | Deduplication logic and `unique_key` value | Deduplicated on `id` only; `unique_key` hashed on `metafield_id` and `source_relation` | Deduplicated on `id`, `owner_id`, and `owner_resource`; `unique_key` hashed on `metafield_id`, `owner_resource_id`, `owner_resource`, and `source_relation` | Shopify changed the underlying `METAFIELD` table's primary key to a composite of `owner_id` and `owner_resource` to fix cross-entity ID collisions. This change does not affect any downstream `shopify_gql__*_metafields` models, since `unique_key` is never selected from `stg_shopify_gql__metafield` into those outputs. |
-
 # dbt_shopify v1.9.2
 
 [PR #164](https://github.com/fivetran/dbt_shopify/pull/164) includes the following updates:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you are **not** using the [Shopify Holistic reporting package](https://github
 ```yml
 packages:
   - package: fivetran/shopify
-    version: [">=1.9.0", "<1.10.0"]
+    version: [">=1.10.0", "<1.11.0"]
 ```
 
 > All required sources and staging models are now bundled into this transformation package. Do not include `fivetran/shopify_source` in your `packages.yml` since this package has been deprecated.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you are **not** using the [Shopify Holistic reporting package](https://github
 ```yml
 packages:
   - package: fivetran/shopify
-    version: [">=1.10.0", "<1.11.0"]
+    version: [">=1.9.0", "<1.10.0"]
 ```
 
 > All required sources and staging models are now bundled into this transformation package. Do not include `fivetran/shopify_source` in your `packages.yml` since this package has been deprecated.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify'
-version: '1.9.2'
+version: '1.10.0'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<3.0.0"]
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify'
-version: '1.10.0'
+version: '1.9.2'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<3.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_integration_tests'
-version: '1.10.0'
+version: '1.9.2'
 profile: 'integration_tests'
 config-version: 2
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_integration_tests'
-version: '1.9.2'
+version: '1.10.0'
 profile: 'integration_tests'
 config-version: 2
 

--- a/integration_tests/seeds/shopify_gql_metafield_data.csv
+++ b/integration_tests/seeds/shopify_gql_metafield_data.csv
@@ -12,3 +12,4 @@ _fivetran_synced,created_at,description,id,key,namespace,owner_id,owner_resource
 2025-07-18 11:04:00,2025-07-14 06:00:00,bea81c1795a612d8fc3a232b156467c0,7011,different_field,bea81c1795a612d8fc3a232b156467c0,1007,shop,string,string,2025-07-18 11:04:00,some_value
 2025-07-18 11:05:00,2025-07-13 05:00:00,bea81c1795a612d8fc3a232b156467c1,7012,extra_field,bea81c1795a612d8fc3a232b156467c1,101,productvariant,boolean,string,2025-07-18 11:05:00,bea81c1795a612d8fc3a232b156467c1
 2025-07-18 11:05:00,2025-07-13 05:00:00,bea81c1795a612d8fc3a232b156467c1,7013,extra-field,bea81c1795a612d8fc3a232b156467c1,101,productvariant,boolean,string,2025-07-19 11:05:00,bea81c1795a612d8fc3a232b156467c1
+2025-07-19 12:00:00,2025-07-19 11:00:00,collision_test_description,7003,collision_test_field,collision_test_namespace,4001,order,string,string,2025-07-19 12:00:00,collision_test_value

--- a/integration_tests/tests/integrity/integrity_metafield_composite_key.sql
+++ b/integration_tests/tests/integrity/integrity_metafield_composite_key.sql
@@ -1,0 +1,62 @@
+{{ config(
+    tags="fivetran_validations",
+    enabled=var('fivetran_validation_tests_enabled', false) and var('shopify_api', 'rest') == 'graphql' and var('shopify_gql_using_metafield', True)
+) }}
+
+-- Confirms the composite-key dedup in stg_shopify_gql__metafield (partitioned on
+-- id, owner_id, owner_resource) does not error or regress: every group should
+-- resolve to exactly one most-recent row, and no two most-recent rows should
+-- collide on unique_key. A non-empty result means the dedup or surrogate key
+-- logic is broken, not that the underlying data is wrong.
+
+with stg as (
+
+    select *
+    from {{ target.schema }}_shopify_dev.stg_shopify_gql__metafield
+
+),
+
+duplicate_most_recent_groups as (
+
+    select
+        metafield_id,
+        owner_resource_id,
+        owner_resource,
+        source_relation,
+        count(*) as most_recent_row_count
+    from stg
+    where is_most_recent_record
+    group by 1, 2, 3, 4
+    having count(*) > 1
+),
+
+duplicate_unique_keys as (
+
+    select
+        unique_key,
+        count(*) as unique_key_count
+    from stg
+    where is_most_recent_record
+    group by 1
+    having count(*) > 1
+),
+
+final as (
+
+    select
+        'duplicate_most_recent_groups' as failure_type,
+        cast(metafield_id as {{ dbt.type_string() }}) as failing_value,
+        most_recent_row_count as failure_count
+    from duplicate_most_recent_groups
+
+    union all
+
+    select
+        'duplicate_unique_keys' as failure_type,
+        cast(unique_key as {{ dbt.type_string() }}) as failing_value,
+        unique_key_count as failure_count
+    from duplicate_unique_keys
+)
+
+select *
+from final

--- a/models/graphql/staging/stg_shopify_gql__metafield.sql
+++ b/models/graphql/staging/stg_shopify_gql__metafield.sql
@@ -36,9 +36,9 @@ final as (
         {{ shopify.fivetran_convert_timezone(column='cast(updated_at as ' ~ dbt.type_timestamp() ~ ')', target_tz=var('shopify_timezone', "UTC"), source_tz="UTC") }} as updated_at,
         {{ shopify.fivetran_convert_timezone(column='cast(_fivetran_synced as ' ~ dbt.type_timestamp() ~ ')', target_tz=var('shopify_timezone', "UTC"), source_tz="UTC") }} as _fivetran_synced,
         lower({{ dbt.concat(["namespace","'_'","key"]) }}) as metafield_reference,
-        row_number() over(partition by id {{ fivetran_utils.partition_by_source_relation(package_name='shopify') }} order by updated_at desc) = 1 as is_most_recent_record,
+        row_number() over(partition by id, owner_id, owner_resource {{ fivetran_utils.partition_by_source_relation(package_name='shopify') }} order by updated_at desc) = 1 as is_most_recent_record,
         source_relation,
-        {{ dbt_utils.generate_surrogate_key(['id', 'source_relation']) }} as unique_key
+        {{ dbt_utils.generate_surrogate_key(['id', 'owner_id', 'owner_resource', 'source_relation']) }} as unique_key
         
     from fields
 )

--- a/models/graphql/staging/stg_shopify_graphql.yml
+++ b/models/graphql/staging/stg_shopify_graphql.yml
@@ -1247,7 +1247,7 @@ models:
       downloadable documents, release dates, images, or part numbers. Metafields are identified by an owner resource, a namespace, and a key and they store a value along with type information for that context. 
     columns:
       - name: unique_key
-        description: Surrogate key hashed on `metafield_id` and `source_relation`.
+        description: Surrogate key hashed on `metafield_id`, `owner_resource_id`, `owner_resource`, and `source_relation`.
         tests:
           - unique
           - not_null


### PR DESCRIPTION
## PR Overview
**Package version introduced in this PR:**
- 1.10.0

**This PR addresses the following Issue/Feature(s):**
- GA-1033804 (Jira)

**Summary of changes:**
- Shopify is changing the `METAFIELD` table's replication key to a composite of `owner_id` and `owner_resource` (in addition to `id`) to fix cross-entity ID collisions that previously caused incorrect deletions. This updates `stg_shopify_gql__metafield`'s deduplication logic and `unique_key` surrogate key to match the new composite key, so the existing `unique_key` uniqueness test doesn't fail once Shopify's one-time resync (targeted weekend of Aug 22-23, 2026) surfaces previously-suppressed duplicate rows.

**Schema/Data change (for the release/1.10.0 changelog):**

| Data Model(s) | Change type | Old | New | Notes |
| ------------- | ----------- | --- | --- | ----- |
| [`stg_shopify_gql__metafield`](https://fivetran.github.io/dbt_shopify/#!/model/model.shopify.stg_shopify_gql__metafield) | Deduplication logic and `unique_key` value | Deduplicated on `id` only; `unique_key` hashed on `metafield_id` and `source_relation` | Deduplicated on `id`, `owner_id`, and `owner_resource`; `unique_key` hashed on `metafield_id`, `owner_resource_id`, `owner_resource`, and `source_relation` | Shopify changed the underlying `METAFIELD` table's primary key to a composite of `owner_id` and `owner_resource` to fix cross-entity ID collisions. This change does not affect any downstream `shopify_gql__*_metafields` models, since `unique_key` is never selected from `stg_shopify_gql__metafield` into those outputs. |

No `--full-refresh` note needed — `stg_shopify_gql__metafield` is materialized as a table and fully rebuilds on a standard run.

### Submission Checklist
- [x] **SHOPIFY-SPECIFIC**: No new fields were added to any model with metafields, so no `downstream_model_column_count` macro changes are needed.
- [ ] Alignment meeting with the reviewer (if needed)
  - [ ] Timeline and validation requirements discussed
- [ ] Provide validation details:
  - [ ] **Validation Steps:** Check for unintentional effects (e.g., add/run consistency & integrity tests)
  - [ ] **Testing Instructions:** Confirm the change addresses the issue(s)
  - [ ] **Focus Areas:** The `unique_key` value change is fully contained to `stg_shopify_gql__metafield` — it is never selected by `get_metafields` into any of the six `shopify_gql__*_metafields` models, so no downstream model output changes.
- [ ] Merge any relevant open PRs into this PR

### Changelog
- [ ] This release now compiles one changelog entry directly on `release/1.10.0` rather than per-PR (see the schema/data change table above for what to fold in) — **do not merge without adding this to the release changelog**.

No REST-side changes are needed (confirmed with engineering on RD-1247795 that this is GraphQL-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)