### PR TITLE
fix: quantity double-counted in GraphQL gross_sales / line_item_enhanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# dbt_shopify v1.9.2-dev
+
+## Bug Fixes
+- Fixed quantity double-counting in the GraphQL models ([Issue #165](https://github.com/fivetran/dbt_shopify/issues/165)). `stg_shopify_gql__order_line.price_shop_amount` is derived from `original_total_set_shop_amount`, which is already a line **total** (unit price × quantity), so multiplying it by `quantity` again produced `quantity² × unit price`:
+  - `int_shopify_gql__orders_order_line_aggregates`: `gross_sales` no longer multiplies by `quantity`. This also corrects `net_sales` and every downstream consumer (`shopify_gql__orders`, `shopify_gql__daily_shop`, customer cohort models).
+  - `shopify_gql__line_item_enhanced`: `total_amount` no longer multiplies by `quantity`, and `unit_amount` is now derived as `price_shop_amount / nullif(quantity, 0)` since the staging column is a line total, not a unit price.
+  - Orders where every line has `quantity = 1` were unaffected; multi-quantity (e.g. wholesale/B2B) lines were inflated by up to several orders of magnitude.
+
 # dbt_shopify v1.9.1
 
 [PR #162](https://github.com/fivetran/dbt_shopify/pull/162) includes the following update:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you are **not** using the [Shopify Holistic reporting package](https://github
 ```yml
 packages:
   - package: fivetran/shopify
-    version: [">=1.9.0", "<1.10.0"]
+    version: [">=1.10.0", "<1.11.0"]
 ```
 
 > All required sources and staging models are now bundled into this transformation package. Do not include `fivetran/shopify_source` in your `packages.yml` since this package has been deprecated.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify'
-version: '1.9.2'
+version: '1.10.0'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<3.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_integration_tests'
-version: '1.9.2'
+version: '1.10.0'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/graphql/intermediate/int_shopify_gql__orders_order_line_aggregates.sql
+++ b/models/graphql/intermediate/int_shopify_gql__orders_order_line_aggregates.sql
@@ -62,7 +62,7 @@ with order_line as (
         sum(coalesce(order_line.quantity, 0)) as order_total_quantity,
         sum(coalesce(tax_aggregates.price, 0)) as order_total_tax,
         sum(coalesce(order_line.total_discount_shop_amount, 0)) as order_total_discount,
-        sum(case when not order_line.is_gift_card and coalesce(orders.financial_status, '') != 'voided' then order_line.quantity * order_line.price_shop_amount else 0 end) as gross_sales,
+        sum(case when not order_line.is_gift_card and coalesce(orders.financial_status, '') != 'voided' then order_line.price_shop_amount else 0 end) as gross_sales,
         sum(coalesce(discount_allocation_agg.discount_allocation_amount, 0)) as discount_allocation_amount,
         sum(coalesce(price_pres_amount, 0)) as total_line_items_price_pres_amount,
         sum(coalesce(price_shop_amount, 0)) as total_line_items_price_shop_amount,

--- a/models/graphql/standardized_models/shopify_gql__line_item_enhanced.sql
+++ b/models/graphql/standardized_models/shopify_gql__line_item_enhanced.sql
@@ -74,10 +74,10 @@ with line_items as (
         null as billing_type,
         p.product_type as product_type,
         li.quantity as quantity,
-        li.price_shop_amount as unit_amount,
+        li.price_shop_amount / nullif(li.quantity, 0) as unit_amount,
         o.total_discounts_shop_amount as discount_amount,
         o.total_tax_shop_amount as tax_amount,
-        (li.quantity * li.price_shop_amount) as total_amount,  
+        li.price_shop_amount as total_amount,
         t.transaction_id as payment_id,
         null as payment_method_id,
         t.gateway as payment_method, -- payment_method in tender_transaction can be something like 'apply_pay', where gateway is like 'gift card' or 'shopify payments' which I think is more relevant here


### PR DESCRIPTION
## PR Overview
**Package version introduced in this PR:**
- 1.10.0

**This PR addresses the following Issue/Feature(s):**
- GA-1035629 (Jira) / [Issue #165](https://github.com/fivetran/dbt_shopify/issues/165)

**Summary of changes:**
- `stg_shopify_gql__order_line.price_shop_amount` is derived from `original_total_set_shop_amount`, which is already a line **total** (unit price × quantity) — not a unit price, unlike the REST equivalent. Two GraphQL models were multiplying it by `quantity` again, producing `quantity² × unit price`. Fixed by removing the extra multiplication:
  - `int_shopify_gql__orders_order_line_aggregates`: `gross_sales` = `sum(price_shop_amount)` (gift-card/voided filter unchanged). Corrects `net_sales` and every downstream consumer (`shopify_gql__orders`, `shopify_gql__daily_shop`, customer cohort models).
  - `shopify_gql__line_item_enhanced`: `total_amount` = `price_shop_amount`; `unit_amount` = `price_shop_amount / nullif(quantity, 0)` (it was previously assigned the line total while named a unit amount).
  - Orders where every line has `quantity = 1` were unaffected; multi-quantity (wholesale/B2B) lines were inflated quadratically — up to ~14x observed on real data.

This carries forward [PR #166](https://github.com/fivetran/dbt_shopify/pull/166) by [@liuhui998](https://github.com/liuhui998), who diagnosed and fixed the bug — merged into this branch to preserve authorship, then rebased onto `release/1.10.0` and re-validated.

**Schema/Data change (for the release/1.10.0 changelog):**

| Data Model(s) | Change type | Old | New | Notes |
| ------------- | ----------- | --- | --- | ----- |
| [`shopify_gql__orders`](https://fivetran.github.io/dbt_shopify/#!/model/model.shopify.shopify_gql__orders), [`shopify_gql__daily_shop`](https://fivetran.github.io/dbt_shopify/#!/model/model.shopify.shopify_gql__daily_shop), customer cohort models | Column value | `gross_sales` / `net_sales` = `Σ quantity² × unit_price` | `gross_sales` / `net_sales` = `Σ quantity × unit_price` | Orders with any line `quantity > 1` were inflated quadratically. Orders where every line has `quantity = 1` are unaffected. |
| [`shopify_gql__line_item_enhanced`](https://fivetran.github.io/dbt_shopify/#!/model/model.shopify.shopify_gql__line_item_enhanced) | Column value | `total_amount = quantity² × unit_price`; `unit_amount` = line total | `total_amount = quantity × unit_price`; `unit_amount` = true unit price | Same root cause, corrected. |

### Submission Checklist
- [x] **SHOPIFY-SPECIFIC**: No new fields added, no `downstream_model_column_count` changes needed.
- [ ] Alignment meeting with the reviewer (if needed)
- [ ] Provide validation details — see testing summary linked in GA-1035629.

### Changelog
- [ ] This release compiles one changelog entry directly on `release/1.10.0` rather than per-PR — fold the schema/data change table above into that entry before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
